### PR TITLE
Request for display number of likes, add new likes and item counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [🙏 Acknowledgements](#acknowledgements)
 - [📝 License](#license)
 
-# 📖 [Movie Monday] <a name="about-project"></a>
+# 📖 [Show Addict] <a name="about-project"></a>
 
 **ShowAddict** is a project where we utilize our HTML, CSS, and JavaScript skills to create a platform that interacts with the TVMAZE API. It enables users to fetch tv series, view summaries, post comments, and express their likes. Furthermore, the platform allows users to update the base API with their comments and likes, providing an interactive and engaging experience for tv series enthusiasts.
 
@@ -73,7 +73,7 @@
 
 ## 🚀 Live Demo <a name="live-demo"></a>
 
-- <a href="">Check out the live demo</a>
+- <a href="https://showaddict-fombi-zuheb.netlify.app">Check out the live demo</a>
 
 ## 🚀 Presentation <a name="presentation"></a>
 

--- a/src/modules/getData.js
+++ b/src/modules/getData.js
@@ -1,12 +1,30 @@
-import { seriesApiUrl } from './api.js';
+import { seriesApiUrl, likeUrl } from './api.js';
+import { itemCounter } from './itemCount.js';
 
 const getSeries = async () => {
   const response = await fetch(seriesApiUrl);
   const seriesData = await response.json();
   const finalData = seriesData.slice(10, 50);
-  //   itemCounter(finalData.length);
+  itemCounter(finalData.length);
   return finalData;
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export { getSeries };
+const getLikes = async () => {
+  const response = await fetch(likeUrl);
+  const likes = await response.json();
+  return likes;
+};
+
+const likePostApi = async (url, id) => {
+  await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      item_id: id,
+    }),
+  });
+};
+
+export { getSeries, getLikes, likePostApi };

--- a/src/modules/itemCount.js
+++ b/src/modules/itemCount.js
@@ -1,0 +1,9 @@
+// import { seriesApiUrl } from './api.js';
+
+const itemCounter = (item) => {
+  const totalCount = document.getElementById('total-count');
+  totalCount.innerHTML = `(${item})`;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { itemCounter };

--- a/src/modules/seriesCard.js
+++ b/src/modules/seriesCard.js
@@ -1,19 +1,20 @@
-import { getSeries } from './getData.js';
+import { getSeries, getLikes, likePostApi } from './getData.js';
+import { likeUrl } from './api.js';
 import modalContents from './modal.js';
 
 const seriesCard = async () => {
-//   const likes = await getLikes(); // Retrieve likes before updating series cards
+  const likes = await getLikes(); // Retrieve likes before updating series cards
   const finalData = await getSeries();
   const seriesCardWrapper = document.getElementById('series');
   seriesCardWrapper.innerHTML = '';
   finalData.forEach((series, index) => {
-    // const likeId = likes.findIndex((like) => Number(like.item_id) === index);
-    // let totalLikes;
-    // if (likeId >= 0) {
-    //   totalLikes = likes[likeId].likes;
-    // } else {
-    //   totalLikes = 0;
-    // }
+    const likeId = likes.findIndex((like) => Number(like.item_id) === index);
+    let totalLikes;
+    if (likeId >= 0) {
+      totalLikes = likes[likeId].likes;
+    } else {
+      totalLikes = 0;
+    }
     const showCard = document.createElement('div');
     showCard.classList.add('show-card');
     const seriesImg = document.createElement('img');
@@ -34,10 +35,10 @@ const seriesCard = async () => {
     likeBtnDiv.appendChild(likeIcon);
     seriesDetails.appendChild(likeBtnDiv);
     showCard.appendChild(seriesDetails);
-    // const likeCount = document.createElement("p");
-    // likeCount.classList.add("like-count");
-    // likeCount.textContent = totalLikes;
-    // showCard.appendChild(likeCount);
+    const likeCount = document.createElement('p');
+    likeCount.classList.add('like-count');
+    likeCount.textContent = totalLikes;
+    showCard.appendChild(likeCount);
     const commentBtn = document.createElement('button');
     commentBtn.classList.add('comments');
     commentBtn.dataset.id = index;
@@ -46,11 +47,11 @@ const seriesCard = async () => {
     seriesCardWrapper.appendChild(showCard);
 
     // Event listener for the like button
-    // likeIcon.addEventListener("click", async (e) => {
-    //   await likePostApi(likeUrl, e.target.dataset.id); // Wait for like to be posted
-    //   totalLikes += 1; // Increment the like count
-    //   likeCount.textContent = totalLikes; // Update the like count immediately
-    // });
+    likeIcon.addEventListener('click', async (e) => {
+      await likePostApi(likeUrl, e.target.dataset.id); // Wait for like to be posted
+      totalLikes += 1; // Increment the like count
+      likeCount.textContent = totalLikes; // Update the like count immediately
+    });
   });
   const popButton = document.querySelectorAll('.comments');
   popButton.forEach((pop) => {


### PR DESCRIPTION
In this branch, we added:
- When the page loads, the webapp the Involvement API to show the item likes and combines them with the data from the base API.
- When the user clicks on the Like button of an item (on Homepage), the interaction is recorded in the Involvement API and the screen is updated.
- Even if the API gives you the number of items, you will create a specific function to calculate it.
- Each counter is implemented as a separate module.
- A counter function is looking for specific DOM elements (e.g. for the comments counter it should look for comments) and make the counting based on what is actually displayed on the page.